### PR TITLE
accept any depth first traversal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "chai": "^4.3.10",
-        "chai-spies": "^1.1.0",
         "mocha": "^10.2.0"
       }
     },
@@ -132,17 +131,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/chai-spies": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/chai-spies/-/chai-spies-1.1.0.tgz",
-      "integrity": "sha512-ikaUhQvQWchRYj2K54itFp3nrcxaFRpSDQxDlRzSn9aWgu9Pi7lD8yFxTso4WnQ39+WZ69oB/qOvqp+isJIIWA==",
-      "engines": {
-        "node": ">= 4.0.0"
-      },
-      "peerDependencies": {
-        "chai": "*"
       }
     },
     "node_modules/chalk": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "license": "ISC",
   "dependencies": {
     "chai": "^4.3.10",
-    "chai-spies": "^1.1.0",
     "mocha": "^10.2.0"
   }
 }

--- a/problems/01-depth-first-traversal.js
+++ b/problems/01-depth-first-traversal.js
@@ -1,34 +1,46 @@
 /*
-Write a function called printDepthFirst that will traverse the given graph
-depth-first, printing each node when visited exactly once, on a newline.
+Write a function called printDepthFirst that will traverse the given
+graph depth-first, printing each node when visited exactly once, on a
+newline.
 
-Hint: How can you use your code from the breadth-first traversal to get a head
-start writing your depth-first traversal?
+Hint: How can you use your code from the breadth-first traversal to get
+a head start writing your depth-first traversal?
 */
 
+/*
+  |           1
+  |          / \
+  |         2---5
+  |        /   /
+  |       3---4--6
+ */
 const adjList = {
   1: [2, 5],
   2: [1, 3, 5],
   3: [2, 4],
   4: [3, 5, 6],
   5: [1, 2, 4],
-  6: [4]
-}
+  6: [4],
+};
 
 function printDepthFirst(start) {
   // Your code here 
 }
 
 // console.log("First Test:")
-// printDepthFirst(3); // Prints 1 through 6 in Depth-first order, starting with 3
-//                     // One possible solution:  3, 4, 6, 5, 2, 1
+// printDepthFirst(3);
+// Prints 1 through 6 in Depth-first order, starting with 3
+// One possible solution:  3, 4, 6, 5, 2, 1
+
 // console.log("Second Test:")
-// printDepthFirst(6); // Prints 1 through 6 in Depth-first order, starting with 6
-//                     // One possible solution:  6, 4, 5, 2, 3, 1
+// printDepthFirst(6);
+// Prints 1 through 6 in Depth-first order, starting with 6
+// One possible solution:  6, 4, 5, 2, 3, 1
+
 // console.log("Third Test:")
-// printDepthFirst(4); // Prints 1 through 6 in Depth-first order, starting with 4
-//                     // One possible solution:  4, 6, 5, 2, 3, 1
+// printDepthFirst(4);
+// Prints 1 through 6 in Depth-first order, starting with 4
+// One possible solution:  4, 6, 5, 2, 3, 1
 
-
-/******************** DO NOT MODIFY ANY CODE BELOW THIS LINE *****************/
+/**************** DO NOT MODIFY ANY CODE BELOW THIS LINE *************/
 module.exports = printDepthFirst;

--- a/test/01-depth-first-traversal-spec.js
+++ b/test/01-depth-first-traversal-spec.js
@@ -1,19 +1,19 @@
-const chai = require('chai');
+const chai = require("chai");
 const expect = chai.expect;
-chai.use(require('chai-spies'));
-const printDepthFirst = require('../problems/01-depth-first-traversal');
+chai.use(require("chai-spies"));
+const printDepthFirst = require("../problems/01-depth-first-traversal");
 
-describe('printDepthFirst', function() {
+describe("printDepthFirst", function () {
   let consoleSpy;
   beforeEach(() => {
-    consoleSpy = chai.spy.on(console, 'log');
+    consoleSpy = chai.spy.on(console, "log");
   });
 
   afterEach(() => {
     chai.spy.restore(console);
   });
 
-  it('printDepthFirst(3) prints out 3, 4, 6, 5, 2, 1', function() {
+  it("printDepthFirst(3) prints out 3, 4, 6, 5, 2, 1", function () {
     printDepthFirst(3);
     expect(consoleSpy).on.nth(1).be.called.with(3);
     expect(consoleSpy).on.nth(2).be.called.with(4);
@@ -23,7 +23,7 @@ describe('printDepthFirst', function() {
     expect(consoleSpy).on.nth(6).be.called.with(1);
   });
 
-  it('printDepthFirst(6) prints out 6, 4, 5, 2, 3, 1', function() {
+  it("printDepthFirst(6) prints out 6, 4, 5, 2, 3, 1", function () {
     printDepthFirst(6);
     expect(consoleSpy).on.nth(1).be.called.with(6);
     expect(consoleSpy).on.nth(2).be.called.with(4);
@@ -33,7 +33,7 @@ describe('printDepthFirst', function() {
     expect(consoleSpy).on.nth(6).be.called.with(1);
   });
 
-  it('printDepthFirst(4) prints out 4, 6, 5, 2, 3, 1', function() {
+  it("printDepthFirst(4) prints out 4, 6, 5, 2, 3, 1", function () {
     printDepthFirst(4);
     expect(consoleSpy).on.nth(1).be.called.with(4);
     expect(consoleSpy).on.nth(2).be.called.with(6);

--- a/test/01-depth-first-traversal-spec.js
+++ b/test/01-depth-first-traversal-spec.js
@@ -1,45 +1,60 @@
 const chai = require("chai");
 const expect = chai.expect;
-chai.use(require("chai-spies"));
 const printDepthFirst = require("../problems/01-depth-first-traversal");
 
 describe("printDepthFirst", function () {
-  let consoleSpy;
+  let consoleLog;
+  let consoleLogArgs;
   beforeEach(() => {
-    consoleSpy = chai.spy.on(console, "log");
+    consoleLog = console.log;
+    consoleLogArgs = [];
+    console.log = (...args) => {
+      consoleLog(...args);
+      consoleLogArgs.push(args);
+    };
   });
 
   afterEach(() => {
-    chai.spy.restore(console);
+    console.log = consoleLog;
   });
 
-  it("printDepthFirst(3) prints out 3, 4, 6, 5, 2, 1", function () {
+  it("printDepthFirst(3) prints a DFS traversal from 3", function () {
     printDepthFirst(3);
-    expect(consoleSpy).on.nth(1).be.called.with(3);
-    expect(consoleSpy).on.nth(2).be.called.with(4);
-    expect(consoleSpy).on.nth(3).be.called.with(6);
-    expect(consoleSpy).on.nth(4).be.called.with(5);
-    expect(consoleSpy).on.nth(5).be.called.with(2);
-    expect(consoleSpy).on.nth(6).be.called.with(1);
+    expect(consoleLogArgs).to.be.deep.oneOf([
+      [[3], [2], [1], [5], [4], [6]],
+      [[3], [4], [5], [1], [2], [6]],
+      [[3], [4], [5], [2], [1], [6]],
+      [[3], [4], [6], [5], [1], [2]],
+      [[3], [4], [6], [5], [2], [1]],
+      [[3], [2], [5], [1], [4], [6]],
+      [[3], [2], [5], [4], [6], [1]],
+    ]);
   });
 
-  it("printDepthFirst(6) prints out 6, 4, 5, 2, 3, 1", function () {
+  it("printDepthFirst(6) prints a DFS traversal from 6", function () {
     printDepthFirst(6);
-    expect(consoleSpy).on.nth(1).be.called.with(6);
-    expect(consoleSpy).on.nth(2).be.called.with(4);
-    expect(consoleSpy).on.nth(3).be.called.with(5);
-    expect(consoleSpy).on.nth(4).be.called.with(2);
-    expect(consoleSpy).on.nth(5).be.called.with(3);
-    expect(consoleSpy).on.nth(6).be.called.with(1);
+    expect(consoleLogArgs).to.be.deep.oneOf([
+      [[6], [4], [3], [2], [1], [5]],
+      [[6], [4], [5], [1], [2], [3]],
+      [[6], [4], [5], [2], [1], [3]],
+      [[6], [4], [5], [2], [3], [1]],
+      [[6], [4], [3], [2], [5], [1]],
+    ]);
   });
 
-  it("printDepthFirst(4) prints out 4, 6, 5, 2, 3, 1", function () {
+  it("printDepthFirst(4) prints a DFS traversal from 4", function () {
     printDepthFirst(4);
-    expect(consoleSpy).on.nth(1).be.called.with(4);
-    expect(consoleSpy).on.nth(2).be.called.with(6);
-    expect(consoleSpy).on.nth(3).be.called.with(5);
-    expect(consoleSpy).on.nth(4).be.called.with(2);
-    expect(consoleSpy).on.nth(5).be.called.with(3);
-    expect(consoleSpy).on.nth(6).be.called.with(1);
+    expect(consoleLogArgs).to.be.deep.oneOf([
+      [[4], [3], [2], [1], [5], [6]],
+      [[4], [5], [1], [2], [3], [6]],
+      [[4], [5], [2], [1], [3], [6]],
+      [[4], [6], [3], [2], [1], [5]],
+      [[4], [6], [5], [1], [2], [3]],
+      [[4], [6], [5], [2], [1], [3]],
+      [[4], [5], [2], [3], [1], [6]],
+      [[4], [6], [5], [2], [3], [1]],
+      [[4], [3], [2], [5], [1], [6]],
+      [[4], [6], [3], [2], [5], [1]],
+    ]);
   });
 });

--- a/test/01-depth-first-traversal-spec.js
+++ b/test/01-depth-first-traversal-spec.js
@@ -18,7 +18,7 @@ describe("printDepthFirst", function () {
     console.log = consoleLog;
   });
 
-  it("printDepthFirst(3) prints a DFS traversal from 3", function () {
+  it("printDepthFirst(3) prints a depth first traversal from 3", () => {
     printDepthFirst(3);
     expect(consoleLogArgs).to.be.deep.oneOf([
       [[3], [2], [1], [5], [4], [6]],
@@ -31,7 +31,7 @@ describe("printDepthFirst", function () {
     ]);
   });
 
-  it("printDepthFirst(6) prints a DFS traversal from 6", function () {
+  it("printDepthFirst(6) prints a depth first traversal from 6", () => {
     printDepthFirst(6);
     expect(consoleLogArgs).to.be.deep.oneOf([
       [[6], [4], [3], [2], [1], [5]],
@@ -42,7 +42,7 @@ describe("printDepthFirst", function () {
     ]);
   });
 
-  it("printDepthFirst(4) prints a DFS traversal from 4", function () {
+  it("printDepthFirst(4) prints a depth first traversal from 4", () => {
     printDepthFirst(4);
     expect(consoleLogArgs).to.be.deep.oneOf([
       [[4], [3], [2], [1], [5], [6]],


### PR DESCRIPTION
1. accept any depth first traversal as correct.  the prior code only accepted one of many possible depth first traversals as a depth first traversal.
2. remove chai-spies in favor of collecting an array of all arguments passed to console.log, which is much easier to compare with other arrays.  this means all the noisy lines like "on.nth(1).be.called.with(3)" can be removed.
3. add a sweet ascii art representation of the graph.